### PR TITLE
Use similar payment method code in config & model

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -2,14 +2,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
 	<default>
 		<payment>
-			<paypal>
+			<vsf-paypal>
 				<active>1</active>
 				<model>Develodesign\PaypalPayment\Model\Payment\Paypal</model>
 				<order_status>pending</order_status>
 				<title>Paypal</title>
 				<allowspecific>0</allowspecific>
 				<group>offline</group>
-			</paypal>
+			</vsf-paypal>
 		</payment>
 	</default>
 </config>


### PR DESCRIPTION
It seems that the payment method won't shop up in the V1 Rest API if the payment method codes used in /etc/config.xml and /Model/Paypal.php are different...

Magento Version 2.2.5 CE

Related API Endpoint:
http://localhost:8590/rest/V1/guest-carts/<YOUR CART ID>/payment-methods