### PR TITLE
Bug/payment method name

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
 	<system>
 		<section id="payment" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="1000" translate="label">
-			<group id="paypal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
+			<group id="vsf-paypal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
 				<label>Paypal</label>
 				<field id="active" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label" type="select">
 					<label>Enabled</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -2,14 +2,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
 	<default>
 		<payment>
-			<paypal>
+			<vsf-paypal>
 				<active>1</active>
 				<model>Develodesign\PaypalPayment\Model\Payment\Paypal</model>
 				<order_status>pending</order_status>
 				<title>Paypal</title>
 				<allowspecific>0</allowspecific>
 				<group>offline</group>
-			</paypal>
+			</vsf-paypal>
 		</payment>
 	</default>
 </config>


### PR DESCRIPTION
It seems that the payment method won't shop up in the V1 Rest API if different payment method codes are used within the plugin...

Magento Version 2.2.5 CE

Related API Endpoint:
http://localhost:8590/rest/V1/guest-carts/YOUR-CART-ID/payment-methods